### PR TITLE
ci: enable npm trusted publishing via `production` environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [quality, test]
     runs-on: ubuntu-latest
+    # `production` GitHub Environment gates the publish. Configure it under
+    # Settings → Environments with optional protection rules (required
+    # reviewers, deployment-branch restriction to tags v*.*.*).
+    environment: production
     permissions:
       contents: read
       id-token: write
@@ -60,5 +64,8 @@ jobs:
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
+      # Trusted Publishing requires npm ≥ 11.5.1; Node 24 ships with
+      # npm 10.x at the time of writing.
+      - run: npm install -g npm@latest
       - run: npm install --no-audit --no-fund
       - run: npm publish --provenance --access public


### PR DESCRIPTION
Wires the workflow up for npm Trusted Publishing (OIDC). After the npm-side configuration below is in place, every `v*.*.*` tag push will publish to npm with provenance and **no `NPM_TOKEN` secret**.

## What this PR changes

- `release` job now runs in the `production` GitHub Environment, so a publish only proceeds if the environment's protection rules (if any) are satisfied.
- Bumps npm to the latest before publish — the trusted-publishing path requires npm ≥ 11.5.1 and Node 24 still ships with npm 10.x.

## What you do (one-time setup)

### 1. Create the `production` GitHub Environment

1. Go to **Settings → Environments → New environment**.
2. Name it `production`.
3. (Optional, recommended) Protection rules:
   - **Required reviewers** — list of GitHub users who must approve the publish job before it runs.
   - **Wait timer** — e.g. 5 min cooling-off window in case you tag the wrong commit.
   - **Deployment branches and tags** → "Selected branches and tags" → add `v*.*.*` tag rule. This blocks an attacker who somehow gets a workflow run on a non-tag from publishing.
4. **Don't add any environment secrets** — the whole point is no token.

### 2. Configure Trusted Publisher on npmjs.com

1. Sign in at npmjs.com and open the `node-red-contrib-join-wait` package page.
2. **Settings → Publishing access → Trusted publishers → Add**.
3. Fill in:
   - **Publisher**: GitHub Actions
   - **Organization or user**: `dxdc`
   - **Repository**: `node-red-contrib-join-wait`
   - **Workflow filename**: `ci.yml`
   - **Environment name**: `production`  ← must match the GitHub environment name above
4. Save.

### 3. Tag and ship

```sh
git tag -a v0.6.0 -m "v0.6.0"
git push origin v0.6.0
```

The workflow will run lint + format + spellcheck + the full Node 20/22/24 matrix, then the `release` job will:
- request approval (if you set required reviewers)
- mint a short-lived OIDC token from GitHub
- exchange it for an npm publish credential
- run `npm publish --provenance --access public` — provenance attestation auto-generated, no `NPM_TOKEN` involved

## Why this is better than `NPM_TOKEN`

- No long-lived secret to rotate or risk leaking.
- Publishing is cryptographically tied to *this exact workflow file in this exact repo on this exact tag*. A leaked GitHub PAT can't publish to npm.
- The provenance attestation that ships with the package proves it was built from this commit on GitHub Actions — visible on the npm page.

## Test plan
- [ ] Configure the `production` environment per step 1 above
- [ ] Add the trusted publisher per step 2 above
- [ ] Merge this PR
- [ ] Tag `v0.6.0` and push the tag
- [ ] Approve the deployment if you set required reviewers
- [ ] Verify the package appears on npm with the provenance badge
