### PR TITLE
fix(editor): listen for editor:close before opening Examples dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.6.3] - 2026-05-09
+
+### Fixed
+
+- **Open example flows button** is finally working. The 0.6.2 fix
+  invoked the import action via `RED.tray.close(cb)`'s callback, but
+  that callback fires before the `editor:close` event — so
+  clipboard.js's `disabled` guard was still set when the action ran,
+  and the dialog never appeared. Now listens for `editor:close`
+  explicitly and defers the action one tick past the synchronous
+  listener chain that clears the flag. Adds a guard against fast
+  double-clicks and a feature-detect fallback to
+  `core:show-import-dialog` for Node-RED < 3.1.
+
+### Changed
+
+- **`engines.node` lowered to `>=18.5`** to match the Node-RED 4.x
+  minimum (per the contrib-node packaging spec). CI matrix gains
+  Node 18 so the claim is verified, not asserted.
+- **Editor template updated to `const`/`let` and arrow functions**.
+  Pure stylistic refactor of `join-wait.html`'s IIFE; no behaviour
+  change. `function` is preserved where Node-RED binds `this`
+  (validators, `oneditprepare`/`save`/`resize`, jQuery `.each`/`.map`
+  callbacks).
+- Dropped the `node-red.examples` field from `package.json` — not
+  part of the packaging spec; examples auto-discover from
+  `examples/`.
+
 ## [0.6.2] - 2026-05-09
 
 ### Fixed

--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,7 @@
         "editableList",
         "httprequest",
         "jsonata",
+        "oneditprepare",
         "oneditresize",
         "localfilesystem",
         "mauriciom",

--- a/join-wait.html
+++ b/join-wait.html
@@ -139,10 +139,7 @@
 
 <script type="text/javascript">
     (function () {
-        // Form-element selectors gathered in one place. Keeps the rest
-        // of the IIFE free of stringly-typed `#node-input-*` lookups
-        // and makes the editor surface auditable at a glance — every
-        // hook into the dialog is listed here.
+        // Every DOM hook the editor uses, in one place.
         const SEL = {
             pathField: '#node-input-pathTopic',
             pathFieldType: '#node-input-pathTopicType',
@@ -168,10 +165,7 @@
             expire: 'node-input-pathsToExpire-container',
         };
         const listInputs = (id) => $('#' + id + ' input[type=text]');
-        // Read the typed-input pair behind the Path field — name + type.
-        // Used wherever both halves are needed together (currently the
-        // output preview); centralising it avoids drift between the two
-        // selectors.
+        // Path-field name + typedInput type, read together to avoid drift.
         const readPathField = () => ({
             name: $(SEL.pathField).val() || 'topic',
             type: $(SEL.pathFieldType).val() || 'msg',
@@ -262,10 +256,8 @@
             return true;
         };
 
-        // Re-validate every row in both editableLists. Called whenever
-        // any row changes, the regex toggle flips, or rows are added /
-        // removed — so duplicate and cross-list overlap warnings are
-        // always in sync with the current state.
+        // Re-validate every row across both lists so duplicate and
+        // cross-list overlap warnings stay in sync.
         const validateAllRows = () => {
             const $paths = listInputs(LIST_ID.paths);
             const $expire = listInputs(LIST_ID.expire);
@@ -298,11 +290,8 @@
         const initEditableList = (containerId, items, opts) => {
             const $container = $('#' + containerId);
             const placeholder = (opts && opts.placeholder) || 'e.g. sensor_1';
-            // A numeric height makes editableList scroll its items
-            // internally past the limit — without it (height:'auto'), a
-            // long list grows the wrapper and visually overlaps the form
-            // rows that follow. The actual height is recomputed in
-            // oneditresize to fill the available tray space.
+            // Numeric height → list scrolls internally past the limit.
+            // Recomputed in oneditresize to fill the tray.
             $container.editableList({
                 addItem: (row, index, data) => {
                     const value = (data && data.value) || '';
@@ -327,11 +316,8 @@
                             }, 0);
                         }
                     });
-                    // Bulk-paste: paste newline-separated text into any
-                    // row to fill the current row + add a new row per
-                    // remaining line. Whitespace-only and empty lines
-                    // are dropped. Single-line pastes fall through to
-                    // the browser's default paste handling.
+                    // Bulk-paste newline-separated text into multiple
+                    // rows. Single-line pastes fall through to default.
                     input.on('paste', (e) => {
                         const clip = (e.originalEvent || e).clipboardData;
                         if (!clip) return;
@@ -399,11 +385,8 @@
             return [];
         };
 
-        // Render a tiny preview of what the path-field property looks
-        // like on the success output, derived from the current Wait paths
-        // list. Prefix matches the typed-input type so flow/global don't
-        // mis-render as msg. Repeated entries surface as `(×n)` so the
-        // n-of-the-same semantic is visible.
+        // Preview of the merged success output. Repeated entries
+        // surface as `(×n)` so the n-of-the-same semantic is visible.
         const updateOutputPreview = () => {
             const paths = readEditableList(LIST_ID.paths);
             const counts = Object.create(null);
@@ -438,11 +421,9 @@
             }
         };
 
-        // Populate the Persist store <select> from the runtime via our
-        // /join-wait/stores admin route. apiRootUrl prefixes the call so
-        // it resolves correctly under custom httpAdminRoot / reverse
-        // proxies; falls back to the bare relative URL on older
-        // Node-RED versions where the setting isn't exposed.
+        // Populate the Persist store <select> from /join-wait/stores.
+        // apiRootUrl prefixes the call so it resolves under custom
+        // httpAdminRoot / reverse proxies.
         const populatePersistStores = (currentValue) => {
             const $sel = $(SEL.persistStore);
             const base = (RED.settings && RED.settings.apiRootUrl) || '';
@@ -482,13 +463,8 @@
         // the next tray drag.
         let lastTraySize = null;
 
-        // Stretch the Wait paths editableList to fill the tray. Mirrors
-        // the pattern in Node-RED core (switch/change/httprequest):
-        // subtract every other row's outer height from the tray height
-        // and give the remainder to the list. The :visible filter mirrors
-        // httprequest so hidden rows (e.g. timeout-hint) are skipped
-        // explicitly. No upper clamp — when the user drags the tray
-        // taller they want to see more rows.
+        // Stretch the Wait paths editableList to fill the tray —
+        // pattern from core switch/change/httprequest.
         const resizePathsList = () => {
             const $form = $(SEL.dialogForm);
             if (!$form.length || !lastTraySize || !lastTraySize.height) return;
@@ -504,14 +480,41 @@
             $('#' + LIST_ID.paths).editableList('height', height);
         };
 
+        // clipboard.js disables import actions while an edit tray is
+        // open, and RED.tray.close(cb) fires cb before the editor:close
+        // event — so we listen for editor:close ourselves and defer one
+        // tick past the synchronous listener chain that clears the flag.
+        // The pending guard suppresses a fast double-click registering
+        // two listeners.
+        let pendingExamplesOpen = false;
         const openExamplesDialog = () => {
-            // The import dialog opens as a modal above the edit tray, so
-            // the user can pick a flow and on close return to this edit
-            // dialog with in-flight edits intact. The earlier approach of
-            // closing the tray first was unreliable (close-callback drops
-            // when stack races editor teardown).
-            if (RED.actions && typeof RED.actions.invoke === 'function') {
-                RED.actions.invoke('core:show-examples-import-dialog');
+            if (pendingExamplesOpen) return;
+            pendingExamplesOpen = true;
+            const invoke = () => {
+                setTimeout(() => {
+                    pendingExamplesOpen = false;
+                    if (!RED.actions || typeof RED.actions.invoke !== 'function') return;
+                    // core:show-examples-import-dialog was added in Node-RED 3.1.
+                    const actions = RED.actions.list && RED.actions.list();
+                    const hasExamples =
+                        Array.isArray(actions) &&
+                        actions.some((a) => (a && a.id) === 'core:show-examples-import-dialog');
+                    RED.actions.invoke(hasExamples ? 'core:show-examples-import-dialog' : 'core:show-import-dialog');
+                }, 0);
+            };
+            if (RED.events && typeof RED.events.once === 'function') {
+                RED.events.once('editor:close', invoke);
+            } else if (RED.events && typeof RED.events.on === 'function') {
+                const handler = () => {
+                    if (RED.events.off) RED.events.off('editor:close', handler);
+                    invoke();
+                };
+                RED.events.on('editor:close', handler);
+            }
+            if (RED.tray && typeof RED.tray.close === 'function') {
+                RED.tray.close();
+            } else {
+                invoke();
             }
         };
 
@@ -540,10 +543,9 @@
                 firstMsg: { value: 'true', required: true },
                 mapPayload: { value: 'false', required: true },
                 disableComplete: { value: false },
-                // Defaults to true so the queue survives a redeploy out of
-                // the box (uses the default in-memory context store).
-                // For full Node-RED restart persistence the user still needs
-                // to point Persist store at a configured persistent store.
+                // On by default → survives redeploys via the in-memory
+                // context store. Restart-persistence still needs Persist
+                // store pointing at a persistent context.
                 persistOnRestart: { value: true },
                 persistStore: { value: '' },
             },
@@ -574,10 +576,7 @@
                         'jsonata',
                     ],
                 });
-                // Spinner accepts decimals (1.5 seconds, 0.25 hours, …)
-                // — the runtime multiplies the value by the unit factor,
-                // so fractional units are valid. step:1 keeps the up/down
-                // arrows snappy for the common integer case.
+                // Decimals OK (runtime multiplies by the unit factor).
                 $(SEL.timeout).spinner({ min: 0.001, step: 1, numberFormat: 'n' });
 
                 initEditableList(LIST_ID.paths, toArray(this.paths), {
@@ -599,8 +598,7 @@
 
                 populatePersistStores(this.persistStore);
 
-                // Hide the Persist store row when Preserve queue is off —
-                // the override is meaningless without persistence enabled.
+                // Persist store row is meaningless without Preserve queue.
                 const $persistRow = $(SEL.persistStoreRow + ', ' + SEL.persistStoreTip);
                 const syncPersistStoreVisibility = () => {
                     $persistRow.toggle($(SEL.persistOnRestart).is(':checked'));
@@ -611,11 +609,8 @@
 
                 $(SEL.examplesButton).on('click', openExamplesDialog);
 
-                // Re-run the editableList resize math when Advanced is
-                // expanded/collapsed — oneditresize only fires on tray
-                // drag, so without this the Wait paths list keeps the
-                // height it had before the toggle and doesn't reclaim
-                // (or yield) space.
+                // Reflow the list when Advanced toggles (oneditresize
+                // only fires on tray drag).
                 $(SEL.advancedDetails).on('toggle', resizePathsList);
             },
             oneditsave: function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-join-wait",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "description": "Node-RED node that joins related messages across multiple paths within a time window — with exact-order matching, regex paths, correlation grouping, reset paths, and queue persistence. Coordinate parallel flows, synchronize events, and debounce sensors.",
     "author": "Daniel Caspi <dan@element26.net>",
     "license": "MIT",
@@ -63,8 +63,7 @@
         "version": ">=3.0.0",
         "nodes": {
             "join-wait": "join-wait.js"
-        },
-        "examples": "examples"
+        }
     },
     "dependencies": {
         "jsonata": "^2.0.5"


### PR DESCRIPTION
## What

The 0.6.2 "Open example flows" button is a no-op in Node-RED. After two failed attempts, here's the actual story:

Node-RED's `clipboard.js` keeps a module-level `disabled` flag toggled by:

```js
RED.events.on("editor:open",  function () { disabled = true });
RED.events.on("editor:close", function () { disabled = false });
```

While `disabled` is `true`, every import/export action returns immediately. So you can't fire the action from inside an open edit dialog.

## Two subtleties earlier attempts missed

1. **`RED.tray.close(cb)` fires `cb` BEFORE the `editor:close` event** in the current Node-RED, so passing the action as a close-callback runs it while `disabled` is still `true`. (PR #15's first attempt at this didn't even close the tray; the second attempt closed it but ran the action via the close callback — both no-ops.)

2. **`clipboard.js`'s `editor:close` listener clears `disabled` synchronously, but listener-order across `RED.events.on` registrations isn't guaranteed.** A bare `RED.events.once('editor:close', invoke)` could still race the order. A `setTimeout(0)` inside the handler defers the action one tick so the flag has definitely flipped.

## Fix

```js
let pendingExamplesOpen = false;
const openExamplesDialog = () => {
    if (pendingExamplesOpen) return;
    pendingExamplesOpen = true;
    const invoke = () => {
        setTimeout(() => {
            pendingExamplesOpen = false;
            // (action lookup + invoke)
        }, 0);
    };
    RED.events.once('editor:close', invoke);
    RED.tray.close();
};
```

Plus:

- **Double-click guard** (`pendingExamplesOpen`) so a fast second click doesn't register two `editor:close` listeners and open the dialog twice.
- **Feature-detect fallback**: `core:show-examples-import-dialog` was added in Node-RED 3.1; older versions use `core:show-import-dialog` (Clipboard tab — user clicks Examples themselves).
- **Older-Node-RED `RED.events.once` fallback**: manual subscribe-then-off if `.once` isn't available.

## Source references

- [`clipboard.js`](https://github.com/node-red/node-red/blob/master/packages/node_modules/%40node-red/editor-client/src/js/ui/clipboard.js): `disabled` flag (line 9), `editor:open`/`editor:close` toggles (~line 1030), `showImportNodes` early-return on `disabled` (~line 619), three import action registrations (~line 723).
- [`tray.js`](https://github.com/node-red/node-red/blob/master/packages/node_modules/%40node-red/editor-client/src/js/ui/tray.js): `close(done)` ordering (~lines 202–237).

## Drive-by

Drops `node-red.examples` from `package.json` — not part of the [packaging spec](https://nodered.org/docs/creating-nodes/examples); silently ignored. Examples auto-discover from `examples/`.

## Test plan

- [x] User confirmed manually: clicking the button opens the Import dialog on the Examples tab
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run spellcheck` clean
- [x] `npm test` — 112 passing
- [x] Rebased onto current master (post #17 + #18); var/let/const + arrow style matches the surrounding code