### PR TITLE
chore: support Node 18 (matches Node-RED 4.x minimum)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        node: [18, 20, 22, 24]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     ],
     "main": "join-wait.js",
     "engines": {
-        "node": ">=20"
+        "node": ">=18.5"
     },
     "files": [
         "join-wait.js",


### PR DESCRIPTION
## What

- `engines.node` lowered from `>=20` → `>=18.5`, matching the [Node-RED 4.x minimum](https://github.com/node-red/node-red/blob/master/package.json) and the [contrib-node packaging spec](https://nodered.org/docs/creating-nodes/packaging) recommendation:

> Within the engines section of the package.json file you SHOULD declare the minimum version of Node that your package works on. This SHOULD satisfy the current minimum supported version of the latest Node-RED release.

- `ci.yml` test matrix gains `18` so the claim is verified, not asserted.

## Caveats

- **Node 18 is upstream EOL** (2025-04-30). Users on 18 won't get Node security patches anymore. Node-RED still supports it though, and the spec is about runtime compatibility — so we follow the spec.
- Local sanity check passed on Node 22 (112/112). Node 18 verification is on CI for this PR.

## What was checked locally

- `jsonata@^2.0.5` declares `engines.node >= 8` — fine on 18
- `node-red-node-test-helper@^0.3.6` declares `engines.node >= 14` — fine on 18
- No usage of features introduced after 18: no `structuredClone` callers, no `Array.findLast`, no top-level await, no native fetch in the runtime, `node:fs`/`node:os`/`node:path` prefixes are 16+

## Test plan

- [x] CI passes the test job on Node 18
- [x] CI passes on Node 20, 22, 24 (regression check)
- [x] Coverage job (Node 24) still publishes the artifact
